### PR TITLE
Auto updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -306,15 +306,15 @@
         },
         {
             "name": "wpackagist-plugin/disable-wordpress-updates",
-            "version": "1.6.7",
+            "version": "1.6.8",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/disable-wordpress-updates/",
-                "reference": "tags/1.6.7"
+                "reference": "tags/1.6.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/disable-wordpress-updates.1.6.7.zip"
+                "url": "https://downloads.wordpress.org/plugin/disable-wordpress-updates.1.6.8.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -342,15 +342,15 @@
         },
         {
             "name": "wpackagist-plugin/wordfence",
-            "version": "7.5.4",
+            "version": "7.5.5",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordfence/",
-                "reference": "tags/7.5.4"
+                "reference": "tags/7.5.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordfence.7.5.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordfence.7.5.5.zip"
             },
             "require": {
                 "composer/installers": "~1.0"


### PR DESCRIPTION
Loading composer repositories with package information Updating dependencies Lock file operations: 0 installs, 2 updates, 0 removals - Upgrading wpackagist-plugin/disable-wordpress-updates (1.6.7 => 1.6.8) - Upgrading wpackagist-plugin/wordfence (7.5.4 => 7.5.5) Installing dependencies from lock file (including require-dev) Package operations: 0 installs, 2 updates, 0 removals - Upgrading wpackagist-plugin/disable-wordpress-updates (1.6.7 => 1.6.8) - Upgrading wpackagist-plugin/wordfence (7.5.4 => 7.5.5) 1 package you are using is looking for funding. Use the `composer fund` command to find out more!