### PR TITLE
Auto updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -306,18 +306,18 @@
         },
         {
             "name": "wpackagist-plugin/disable-wordpress-updates",
-            "version": "1.6.7",
+            "version": "1.6.8",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/disable-wordpress-updates/",
-                "reference": "tags/1.6.7"
+                "reference": "tags/1.6.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/disable-wordpress-updates.1.6.7.zip"
+                "url": "https://downloads.wordpress.org/plugin/disable-wordpress-updates.1.6.8.zip"
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/disable-wordpress-updates/"
@@ -335,25 +335,25 @@
                 "url": "https://downloads.wordpress.org/plugin/litespeed-cache.3.6.4.zip"
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/litespeed-cache/"
         },
         {
             "name": "wpackagist-plugin/wordfence",
-            "version": "7.5.4",
+            "version": "7.5.5",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordfence/",
-                "reference": "tags/7.5.4"
+                "reference": "tags/7.5.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordfence.7.5.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordfence.7.5.5.zip"
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wordfence/"


### PR DESCRIPTION
Loading composer repositories with package information Updating dependencies Lock file operations: 0 installs, 2 updates, 0 removals - Upgrading wpackagist-plugin/disable-wordpress-updates (1.6.7 => 1.6.8) - Upgrading wpackagist-plugin/wordfence (7.5.4 => 7.5.5) Installing dependencies from lock file (including require-dev) Package operations: 0 installs, 2 updates, 0 removals - Upgrading wpackagist-plugin/disable-wordpress-updates (1.6.7 => 1.6.8) - Upgrading wpackagist-plugin/wordfence (7.5.4 => 7.5.5) 1 package you are using is looking for funding. Use the `composer fund` command to find out more!