### PR TITLE
Auto updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -158,20 +158,20 @@
         },
         {
             "name": "johnpbloch/wordpress",
-            "version": "5.7.2",
+            "version": "5.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress.git",
-                "reference": "be44aeabc63a584a4b1ef4a193f36c3f710a162a"
+                "reference": "b8a04c387a9bb0d9e59e99b0cf233eaffaa59e5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/be44aeabc63a584a4b1ef4a193f36c3f710a162a",
-                "reference": "be44aeabc63a584a4b1ef4a193f36c3f710a162a",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/b8a04c387a9bb0d9e59e99b0cf233eaffaa59e5e",
+                "reference": "b8a04c387a9bb0d9e59e99b0cf233eaffaa59e5e",
                 "shasum": ""
             },
             "require": {
-                "johnpbloch/wordpress-core": "5.7.2",
+                "johnpbloch/wordpress-core": "5.7.3",
                 "johnpbloch/wordpress-core-installer": "^1.0 || ^2.0",
                 "php": ">=5.6.20"
             },
@@ -200,20 +200,20 @@
                 "source": "http://core.trac.wordpress.org/browser",
                 "wiki": "http://codex.wordpress.org/"
             },
-            "time": "2021-05-13T00:40:29+00:00"
+            "time": "2021-09-09T02:45:58+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "5.7.2",
+            "version": "5.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "d0f5bdeb81800b6bcefee723ebf928b5677e2e86"
+                "reference": "35bb368e1faa16dc4c0252f8b059f209f33a8d51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/d0f5bdeb81800b6bcefee723ebf928b5677e2e86",
-                "reference": "d0f5bdeb81800b6bcefee723ebf928b5677e2e86",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/35bb368e1faa16dc4c0252f8b059f209f33a8d51",
+                "reference": "35bb368e1faa16dc4c0252f8b059f209f33a8d51",
                 "shasum": ""
             },
             "require": {
@@ -221,7 +221,7 @@
                 "php": ">=5.6.20"
             },
             "provide": {
-                "wordpress/core-implementation": "5.7.2"
+                "wordpress/core-implementation": "5.7.3"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -248,7 +248,7 @@
                 "source": "https://core.trac.wordpress.org/browser",
                 "wiki": "https://codex.wordpress.org/"
             },
-            "time": "2021-05-13T00:40:25+00:00"
+            "time": "2021-09-09T02:45:54+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",
@@ -306,18 +306,18 @@
         },
         {
             "name": "wpackagist-plugin/disable-wordpress-updates",
-            "version": "1.6.7",
+            "version": "1.6.8",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/disable-wordpress-updates/",
-                "reference": "tags/1.6.7"
+                "reference": "tags/1.6.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/disable-wordpress-updates.1.6.7.zip"
+                "url": "https://downloads.wordpress.org/plugin/disable-wordpress-updates.1.6.8.zip"
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/disable-wordpress-updates/"
@@ -335,25 +335,25 @@
                 "url": "https://downloads.wordpress.org/plugin/litespeed-cache.3.6.4.zip"
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/litespeed-cache/"
         },
         {
             "name": "wpackagist-plugin/wordfence",
-            "version": "7.5.4",
+            "version": "7.5.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordfence/",
-                "reference": "tags/7.5.4"
+                "reference": "tags/7.5.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordfence.7.5.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordfence.7.5.6.zip"
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wordfence/"


### PR DESCRIPTION
Loading composer repositories with package information Updating dependencies Lock file operations: 0 installs, 4 updates, 0 removals - Upgrading johnpbloch/wordpress (5.7.2 => 5.7.3) - Upgrading johnpbloch/wordpress-core (5.7.2 => 5.7.3) - Upgrading wpackagist-plugin/disable-wordpress-updates (1.6.7 => 1.6.8) - Upgrading wpackagist-plugin/wordfence (7.5.4 => 7.5.6) Installing dependencies from lock file (including require-dev) Package operations: 0 installs, 4 updates, 0 removals - Upgrading johnpbloch/wordpress-core (5.7.2 => 5.7.3) - Upgrading johnpbloch/wordpress (5.7.2 => 5.7.3) - Upgrading wpackagist-plugin/disable-wordpress-updates (1.6.7 => 1.6.8) - Upgrading wpackagist-plugin/wordfence (7.5.4 => 7.5.6) 1 package you are using is looking for funding. Use the `composer fund` command to find out more!